### PR TITLE
Add `remove_filediff_comment` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,11 @@ The script to run before generating the filediff comment.
 
 **`file_details_open` (optional, default: false)**
 
-Open the file details when the comment is created
+Open the file details when the comment is created.
+
+**`remove_filediff_comment` (optional, default: false)**
+
+Removes previous filediff comments before creating a new one.
 
 ## Changelog
 

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
   file_details_open:
     default: false
     description: Do not render a collapsible section for the files
+  remove_filediff_comment:
+    default: false
+    description: Removes previous filediff comments
 runs:
   using: node20
   main: dist/index.js

--- a/index.ts
+++ b/index.ts
@@ -64,8 +64,8 @@ const getBranchStats = async (
     info(`[${branch}] Running ${script}`);
     const commands = script.split('&&').map((cmd) => cmd.trim());
     for (const cmd of commands) {
-      const [cmdName, ...cmdArgs] = cmd.split(' ');
-      await exec(cmdName, cmdArgs, {cwd});
+      const [cmdName, ...cmdArgs] = cmd.split(/\s+/);
+      await exec(cmdName!, cmdArgs, {cwd});
     }
   }
 
@@ -97,18 +97,18 @@ export const getStatComment = (
     added: 0,
   };
 
-  const getDiff = (a, b) => prettyBytes(a - b, {signed: true});
+  const getDiff = (a: number, b: number) => prettyBytes(a - b, {signed: true});
   const totalDiff = {
     size: getDiff(prStats.totalSize, targetStats.totalSize),
     gzip: getDiff(prStats.totalGzip, targetStats.totalGzip),
     brotli: getDiff(prStats.totalBrotli, targetStats.totalBrotli),
   };
 
-  let fileColumns = [];
+  let fileColumns: string[] = [];
   Object.entries(prStats.files).forEach(([filePath, {size, brotli, gzip}]) => {
     const targetFile = targetStats.files[filePath];
 
-    if (targetFile === undefined) {
+    if (!targetFile) {
       // File in PR is not in target branch (added)
       fileTotals.added = fileTotals.added + 1;
       fileColumns.push(
@@ -135,7 +135,8 @@ export const getStatComment = (
     },
   );
 
-  const pluralize = (count, single, plural) => (count === 1 ? single : plural);
+  const pluralize = (count: number, single: string, plural: string) =>
+    count === 1 ? single : plural;
 
   const fChangedText = pluralize(
     fileTotals.changed,
@@ -184,8 +185,7 @@ const run = async () => {
     const dirGlob = getInput('dir_glob', {required: true});
     const script = getInput('pre_diff_script');
     const fileDetailsOpen = getInput('file_details_open');
-
-    // TODO: Check if a comment already exists and remove it
+    const removeFilediffComment = getInput('remove_filediff_comment');
 
     const [targetStats, prStats] = await Promise.all([
       getBranchStats(targetBranch, dirGlob, script),
@@ -195,28 +195,30 @@ const run = async () => {
     // No changes found, exit early
     if (targetStats.totalSize === prStats.totalSize) return;
 
+    if (removeFilediffComment === 'true') {
+      // Remove existing filediff comment
+      const comments = await octokit.rest.issues.listComments({
+        owner,
+        repo,
+        issue_number: prNumber,
+      });
+
+      for (let comment of comments.data) {
+        if (comment.body?.startsWith(commentHash)) {
+          await octokit.rest.issues.deleteComment({
+            owner,
+            repo,
+            comment_id: comment.id,
+          });
+        }
+      }
+    }
+
     const commentBody = getStatComment(
       targetStats,
       prStats,
       fileDetailsOpen === 'true',
     );
-
-    // Remove existing filediff comment
-    const comments = await octokit.rest.issues.listComments({
-      owner,
-      repo,
-      issue_number: prNumber,
-    });
-
-    for (let comment of comments.data) {
-      if (comment.body.startsWith('<!-- @alex-page was here -->')) {
-        await octokit.rest.issues.deleteComment({
-          owner,
-          repo,
-          comment_id: comment.id,
-        });
-      }
-    }
 
     await octokit.rest.issues.createComment({
       owner,
@@ -225,7 +227,9 @@ const run = async () => {
       body: commentBody,
     });
   } catch (error) {
-    setFailed(error.message);
+    setFailed(
+      error instanceof Error ? error.message : 'An unexpected error occurred',
+    );
   }
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,8 @@
   "compilerOptions": {
     "target": "es2022",
     "module": "NodeNext",
-    "moduleResolution": "NodeNext"
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noUncheckedIndexedAccess": true
   }
 }


### PR DESCRIPTION
This PR adds support for conditionally applying the remove previous filediff comment behavior (previously enabled by default). By persisting filediff comments users can now assess and discuss the stats before and after file changes. Additionally, this PR updates the `tsconfig.json` with stricter settings, applies the respective changes, and optimizes a few code paths to be asynchronous.