### PR TITLE
Eliminate common paths in filename output

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -199,7 +199,7 @@ export const getStatComment = (
   <details${fileDetailsOpen ? ' open' : ''}>
     <summary><sub>${detailsSummaryText.join(', ')}</sub></summary>
 
-    ${commonFilePath ? `All changed files are in ${commonFilePath}` : ''}
+${commonFilePath ? `All changed files are in ${commonFilePath}` : ''}
 
 | Filename | size  | gzip | brotli |
 |:--- | ---:| ---:| ---:|


### PR DESCRIPTION
The goal here is to turn:

  <details open>
    <summary><sub>2 files changed</sub></summary>

| Filename | size  | gzip | brotli |
|:--- | ---:| ---:| ---:|
| <sub>packages/admin-ui-foundations/dist/filediff/chunks/TimePickerMain.js</sub> | <sub>5.12 kB `-531 B`</sub> | <sub>2.26 kB `-256 B`</sub> | <sub>1.98 kB `-226 B`</sub> |
| <sub>packages/admin-ui-foundations/dist/filediff/chunks/all-components.js</sub> | <sub>39.3 kB `+8.54 kB`</sub> | <sub>13 kB `+2.13 kB`</sub> | <sub>11.5 kB `+1.84 kB`</sub> |
  </details>

Into

  <details open>
    <summary><sub>2 files changed</sub></summary>

All changed files are in packages/admin-ui-foundations/dist/filediff/chunks/

| Filename | size  | gzip | brotli |
|:--- | ---:| ---:| ---:|
| <sub>TimePickerMain.js</sub> | <sub>5.12 kB `-531 B`</sub> | <sub>2.26 kB `-256 B`</sub> | <sub>1.98 kB `-226 B`</sub> |
| <sub>all-components.js</sub> | <sub>39.3 kB `+8.54 kB`</sub> | <sub>13 kB `+2.13 kB`</sub> | <sub>11.5 kB `+1.84 kB`</sub> |
  </details>

I haven't actually tested this - I'm not sure what the best way to test this is.